### PR TITLE
don't delete loras_tags.json on JSONDecodeError

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -66,7 +66,7 @@ def load_json_from_file(file_path):
         return None
     except json.JSONDecodeError:
         print(f"Error decoding JSON in file: {file_path}")
-        return None
+        raise
 
 def save_dict_to_json(data_dict, file_path):
     try:


### PR DESCRIPTION
I found that some models don't have accurate tags (especially older ones when it seemed like there were fewer rules on CivitAI). I edited the loras_tags.json file manually, but accidentally left a trailing comma. Returning None on the JSONDecodeError led to the entire file being overwritten (and the old, incorrect tags being saved, to boot!). Thankfully, I had the JSON file open and was able to recover from disk :)

It feels more user friendly to me to just raise the error, let the workflow fail, and give the user a chance to fix it (or delete it themselves, I suppose).